### PR TITLE
feat: add basic React TypeScript Ludo game

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # Ludo
+
+A simple Ludo game built with React and TypeScript. The board renders using a CSS grid and allows four players to move a single token around the track based on dice rolls.
+
+## Scripts
+
+- `npm test` – placeholder test script.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Ludo App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "ludo",
+  "version": "1.0.0",
+  "description": "Simple Ludo game built with React and TypeScript",
+  "scripts": {
+    "test": "echo \"No tests available\" && exit 0"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.36",
+    "@types/react-dom": "^18.2.14",
+    "typescript": "^5.2.2",
+    "vite": "^5.0.0"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import LudoGame from './LudoGame';
+
+const App: React.FC = () => {
+  return <LudoGame />;
+};
+
+export default App;

--- a/src/Dice.tsx
+++ b/src/Dice.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+interface DiceProps {
+  value: number | null;
+  onRoll: () => void;
+}
+
+const Dice: React.FC<DiceProps> = ({ value, onRoll }) => (
+  <div>
+    <button onClick={onRoll}>Roll</button>
+    {value !== null && <span> {value}</span>}
+  </div>
+);
+
+export default Dice;

--- a/src/LudoBoard.tsx
+++ b/src/LudoBoard.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+interface Coord {
+  x: number;
+  y: number;
+}
+
+interface Token {
+  player: number;
+  position: number;
+}
+
+interface BoardProps {
+  path: Coord[];
+  tokens: Token[];
+}
+
+const colors = ['red', 'blue', 'green', 'yellow'];
+const size = 15;
+
+const LudoBoard: React.FC<BoardProps> = ({ path, tokens }) => {
+  const cells: JSX.Element[] = [];
+
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      const pathIndex = path.findIndex(p => p.x === x && p.y === y);
+      const token = tokens.find(
+        t => path[t.position].x === x && path[t.position].y === y
+      );
+
+      const classNames = ['cell'];
+      if (pathIndex !== -1) classNames.push('path');
+
+      cells.push(
+        <div className={classNames.join(' ')} key={`${x}-${y}`}>
+          {token && <div className={`token ${colors[token.player]}`} />}
+        </div>
+      );
+    }
+  }
+
+  return <div className="board">{cells}</div>;
+};
+
+export default LudoBoard;

--- a/src/LudoGame.tsx
+++ b/src/LudoGame.tsx
@@ -1,0 +1,108 @@
+import React, { useState } from 'react';
+import LudoBoard from './LudoBoard';
+import Dice from './Dice';
+
+interface Coord {
+  x: number;
+  y: number;
+}
+
+interface Token {
+  player: number;
+  position: number;
+}
+
+const colors = ['red', 'blue', 'green', 'yellow'];
+
+const path: Coord[] = [
+  { x: 1, y: 6 },
+  { x: 2, y: 6 },
+  { x: 3, y: 6 },
+  { x: 4, y: 6 },
+  { x: 5, y: 6 },
+  { x: 5, y: 5 },
+  { x: 5, y: 4 },
+  { x: 5, y: 3 },
+  { x: 5, y: 2 },
+  { x: 5, y: 1 },
+  { x: 5, y: 0 },
+  { x: 6, y: 0 },
+  { x: 7, y: 0 },
+  { x: 7, y: 1 },
+  { x: 7, y: 2 },
+  { x: 7, y: 3 },
+  { x: 7, y: 4 },
+  { x: 7, y: 5 },
+  { x: 8, y: 5 },
+  { x: 9, y: 5 },
+  { x: 10, y: 5 },
+  { x: 11, y: 5 },
+  { x: 12, y: 5 },
+  { x: 13, y: 5 },
+  { x: 13, y: 6 },
+  { x: 13, y: 7 },
+  { x: 12, y: 7 },
+  { x: 11, y: 7 },
+  { x: 10, y: 7 },
+  { x: 9, y: 7 },
+  { x: 8, y: 7 },
+  { x: 8, y: 8 },
+  { x: 8, y: 9 },
+  { x: 8, y: 10 },
+  { x: 8, y: 11 },
+  { x: 8, y: 12 },
+  { x: 8, y: 13 },
+  { x: 7, y: 13 },
+  { x: 7, y: 12 },
+  { x: 7, y: 11 },
+  { x: 7, y: 10 },
+  { x: 7, y: 9 },
+  { x: 7, y: 8 },
+  { x: 6, y: 8 },
+  { x: 5, y: 8 },
+  { x: 4, y: 8 },
+  { x: 3, y: 8 },
+  { x: 2, y: 8 },
+  { x: 1, y: 8 },
+  { x: 0, y: 8 },
+  { x: 0, y: 7 },
+  { x: 0, y: 6 }
+];
+
+const initialTokens: Token[] = [
+  { player: 0, position: 0 },
+  { player: 1, position: 13 },
+  { player: 2, position: 26 },
+  { player: 3, position: 39 }
+];
+
+const LudoGame: React.FC = () => {
+  const [tokens, setTokens] = useState<Token[]>(initialTokens);
+  const [current, setCurrent] = useState(0);
+  const [dice, setDice] = useState<number | null>(null);
+
+  const rollDice = () => {
+    const value = Math.floor(Math.random() * 6) + 1;
+    setDice(value);
+    setTokens(prev =>
+      prev.map(t =>
+        t.player === current
+          ? { ...t, position: (t.position + value) % path.length }
+          : t
+      )
+    );
+    setCurrent(prev => (prev + 1) % colors.length);
+  };
+
+  return (
+    <div>
+      <LudoBoard path={path} tokens={tokens} />
+      <div className="controls">
+        <p>Current player: {colors[current]}</p>
+        <Dice value={dice} onRoll={rollDice} />
+      </div>
+    </div>
+  );
+};
+
+export default LudoGame;

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,47 @@
+body {
+  margin: 0;
+  font-family: sans-serif;
+}
+
+.board {
+  display: grid;
+  grid-template-columns: repeat(15, 30px);
+  grid-template-rows: repeat(15, 30px);
+  width: 450px;
+}
+
+.cell {
+  width: 30px;
+  height: 30px;
+  box-sizing: border-box;
+  border: 1px solid #ddd;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.path {
+  background: #f5f5f5;
+}
+
+.token {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+}
+
+.token.red {
+  background: red;
+}
+
+.token.blue {
+  background: blue;
+}
+
+.token.green {
+  background: green;
+}
+
+.token.yellow {
+  background: yellow;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["DOM", "ES2020"],
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- build minimal React + TypeScript setup for a simple Ludo game
- render board with tokens and dice roll interaction
- document placeholder test script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896368e0ba8832eb1577a6455f8e649